### PR TITLE
Do not rely on #!/usr/bin/env for the Python helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ set(QT_MIN_VERSION "5.7.0")
 #-----------------------------------------------------------------------------
 #                              DEPENDENCIES
 #-----------------------------------------------------------------------------
+# Python3 (search for this first so that we will not get Python2 by accident)
+find_package(PythonInterp 3 REQUIRED)
+
 # Qt5
 find_package(Qt5 REQUIRED COMPONENTS
     Core

--- a/plugins/ufw/helper/kcm_ufw_helper.py.cmake
+++ b/plugins/ufw/helper/kcm_ufw_helper.py.cmake
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!@PYTHON_EXECUTABLE@
 
 #
 # UFW KControl Module


### PR DESCRIPTION
Distros do not like having script interpreters soft-coded that way. See,
e.g.: https://fedoraproject.org/wiki/Packaging:Guidelines#Shebang_lines

Therefore, look for the actual path to the Python 3 interpreter and
substitute it in kcm_ufw_helper.py (which is already run through
configure_file anyway).

The only tricky thing is that finding KCMUtils will look for a Python
interpreter without specifying a version and take the first one it
finds. Unfortunately, that is typically /usr/bin/python, which is often
(still) Python 2. So a later call to "find_package(PythonInterp 3
REQUIRED)" will then attempt to use the cached PYTHON_EXECUTABLE and
fail because it is not the required version. Thus, look for Python 3
before looking for the Qt5 and KF5 libraries.